### PR TITLE
do not fail for wikis with more than 500 pages

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -292,16 +292,29 @@ sub get_mw_tracked_namespaces {
 sub get_mw_all_pages {
 	my $pages = shift;
 	# No user-provided list, get the list of pages from the API.
-	my $mw_pages = $mediawiki->list({
+	my $query = {
 		action => 'query',
 		list => 'allpages',
 		aplimit => 'max'
-	});
-	if (!defined($mw_pages)) {
-		fatal_mw_error("get the list of wiki pages");
-	}
-	foreach my $page (@{$mw_pages}) {
-		$pages->{$page->{title}} = $page;
+	};
+	my $curpage;
+	my $oldpage = '';
+	while (1) {
+		if (defined($curpage)) {
+			if ($oldpage eq $curpage) {
+			    last;
+			}
+			$query->{apfrom} = $curpage;
+			$oldpage = $curpage;
+		}
+		my $mw_pages = $mediawiki->list($query);
+		if (!defined($mw_pages)) {
+			fatal_mw_error("get the list of wiki pages");
+		}
+		foreach my $page (@{$mw_pages}) {
+			$pages->{$page->{title}} = $page;
+			$curpage = $page->{title};
+		}
 	}
 	return;
 }


### PR DESCRIPTION
This improves handling of large wikis, but in my tests it seemed to
hang on really large wikis (e.g. Wikipedia).

Closes: #32