### PR TITLE
All revisions imported twice

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -809,7 +809,10 @@ sub get_more_refs {
 sub mw_import {
 	# multiple import commands can follow each other.
 	my @refs = (shift, get_more_refs('import'));
+	my $processedRefs;
 	foreach my $ref (@refs) {
+		next if $processedRefs->{$ref}; # skip duplicates: "import refs/heads/master" being issued twice; TODO: why?
+		$processedRefs->{$ref} = 1;
 		mw_import_ref($ref);
 	}
 	print {*STDOUT} "done\n";


### PR DESCRIPTION
For a `git clone` strangely, `import refs/heads/master` is sent twice.
Fix/workaround: skip duplicate refs in `mw_import`.

Fixes #29.