### PR TITLE
fix for namespace lookup on push

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -1370,8 +1370,9 @@ sub get_mw_namespace_id {
 }
 
 sub get_mw_namespace_id_for_page {
-	my $namespace = shift;
-	if ($namespace =~ /^([^:]*):/) {
+	my $page = shift;
+	if ($page =~ /^([^:]*):/) {
+		my $namespace = $1;
 		return get_mw_namespace_id($namespace);
 	} else {
 		return;


### PR DESCRIPTION
The code which looks up a file's namespace during a push will always fail to find the namespace code for a page that is not in the default namespace. This is because it always uses the full page name to check the namespace, instead of the actual namespace matched by the regex. This means it will write notANameSpace cache entries for every page in the repo to the git config, and this eventually cause what appears to be some sort of overflow error for moderate to large wikis during a large push.