### PR TITLE
Misc. mediafile download fixes

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -504,6 +504,12 @@ sub download_mw_mediafile {
 		# "Wide character in subroutine entry".
 		$response->decode();
 		return $response->content();
+	} elsif (($download_url !~ /^\Q$url\E/) and ($download_url =~ m{\Q$wiki_name\E/})) {
+		# We may have failed because the URL returned from the API
+		# is missing something (e.g. "user:password@"). Retry with a
+		# corresponding URL constructed from our original $url.
+		$download_url =~ s{.*?\Q$wiki_name\E/}{$url/};
+		return download_mw_mediafile($download_url);
 	} else {
 		print {*STDERR} "Error downloading mediafile from :\n";
 		print {*STDERR} "URL: ${download_url}\n";

--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -481,14 +481,18 @@ sub get_mw_mediafile_for_page_revision {
 	# If not defined it means there is no revision of the file for
 	# given timestamp.
 	if (defined($file->{imageinfo})) {
-		$mediafile{title} = $filename;
-
 		my $fileinfo = pop(@{$file->{imageinfo}});
-		$mediafile{timestamp} = $fileinfo->{timestamp};
 		# Mediawiki::API's download function doesn't support https URLs
 		# and can't download old versions of files.
-		print {*STDERR} "\tDownloading file $mediafile{title}, version $mediafile{timestamp}\n";
-		$mediafile{content} = download_mw_mediafile($fileinfo->{url});
+		print {*STDERR} "\tDownloading file $filename, version $fileinfo->{timestamp}\n";
+		my $content = download_mw_mediafile($fileinfo->{url});
+		if (defined($content)) {
+			$mediafile{content} = $content;
+			$mediafile{title} = $filename;
+			$mediafile{timestamp} = $fileinfo->{timestamp};
+		} else {
+			print {*STDERR} "\tFAILED downloading $fileinfo->{url}! Skipping!\n";
+		}
 	}
 	return %mediafile;
 }
@@ -514,7 +518,7 @@ sub download_mw_mediafile {
 		print {*STDERR} "Error downloading mediafile from :\n";
 		print {*STDERR} "URL: ${download_url}\n";
 		print {*STDERR} 'Server response: ' . $response->code . q{ } . $response->message . "\n";
-		exit 1;
+		return;
 	}
 }
 


### PR DESCRIPTION
Here are a couple of patches I needed to apply in order to sucessfully import a mediawiki instance at $dayjob. The first patch is a clear improvement IMHO, whereas the second patch might be more controversial.