### PR TITLE
Don't add the startid if it is 1

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -681,13 +681,17 @@ sub fetch_mw_revisions_for_page {
 		prop => 'revisions',
 		rvprop => 'ids',
 		rvdir => 'newer',
-		rvstartid => $fetch_from,
 		rvlimit => 500,
 		pageids => $id,
 
 		# Let MediaWiki know that we support the latest API.
 		continue => '',
 	};
+
+	# Don't add the start if it is 1 since not all pages start at 1
+	if ($fetch_from != 1) {
+		$query->{rvstartid} = $fetch_from;
+	}
 
 	my $revnum = 0;
 	# Get 500 revisions at a time due to the mediawiki api limit


### PR DESCRIPTION
On a wiki where MediaWiki:Sidebar does not start with rev 1:

    $ git clone -c remote.origin.pages=MediaWiki:Sidebar mediawiki::https://www.wiki.org/w/
		…
		page 1/1: MediaWiki:Sidebar
		  Found 0 revision(s).
		You appear to have cloned an empty MediaWiki.
		fatal: could not read ref refs/mediawiki/origin/master

After this patch

    $ git clone -c  remote.origin.pages=MediaWiki:Sidebar mediawiki::https://www.wiki.org/w/
		…
		page 1/1: MediaWiki:Sidebar
		  Found 115 revision(s).
		Namespace MediaWiki not found in cache, querying the wiki ...
		1/115: Revision #7 of MediaWiki:Sidebar
		2/115: Revision #8 of MediaWiki:Sidebar
		3/115: Revision #9 of MediaWiki:Sidebar
		4/115: Revision #10 of MediaWiki:Sidebar
		5/115: Revision #11 of MediaWiki:Sidebar
		6/115: Revision #12 of MediaWiki:Sidebar

Fixes #70