### PR TITLE
Use rvcontinue instead of rvstartid for new API

### DIFF
--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -706,7 +706,7 @@ sub fetch_mw_revisions_for_page {
 		if ($result->{'query-continue'}) { # For legacy APIs
 			$query->{rvstartid} = $result->{'query-continue'}->{revisions}->{rvstartid};
 		} elsif ($result->{continue}) { # For newer APIs
-			$query->{rvstartid} = $result->{continue}->{rvcontinue};
+			$query->{rvcontinue} = $result->{continue}->{rvcontinue};
 			$query->{continue} = $result->{continue}->{continue};
 		} else {
 			last;


### PR DESCRIPTION
Before this, only the first 500 revisions would be recognized on “newer” MediaWiki sites. This is
demonstrated in the bug #73.

After, all 900+ revisions of Comedy_Circus on enwiki are fetched (DEBUG envvar is from my own debug
branch):

	DEBUG=yes git clone -c remote.origin.pages=Comedy_Circus mediawiki::https://en.wikipedia.org/w BO
	Cloning into 'BO'...
	Searching revisions...
	No previous mediawiki revision found, fetching from beginning.
	Fetching & writing export data by pages...
	Listing pages on remote wiki...
	1 pages found.
	page 1/1: Comedy Circus
	  Found 992 revision(s).
	1/992: Revision #145549344 of Comedy_Circus
	2/992: Revision #145549475 of Comedy_Circus
	3/992: Revision #145550812 of Comedy_Circus
	4/992: Revision #145551110 of Comedy_Circus
	…
	989/992: Revision #1064847286 of Comedy_Circus
	990/992: Revision #1064932681 of Comedy_Circus
	991/992: Revision #1066257115 of Comedy_Circus
	992/992: Revision #1069595229 of Comedy_Circus

Fixes #73