### PR TITLE
Update user docs

### DIFF
--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -2,6 +2,8 @@
 
 You need to have Git installed on your machine. See the [help with setup for Windows](http://help.github.com/win-set-up-git/), [Mac](http://help.github.com/mac-set-up-git/) or [Linux](http://help.github.com/linux-set-up-git/).
 
+*Note: The Git project does not contain the latest version available in the master of this repository. See https://github.com/Git-Mediawiki/Git-Mediawiki/issues/82 on the matter.*
+
 ### Dependencies
 
 You need to have the following Perl packages installed:

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -10,25 +10,13 @@ You need to have the following Perl packages installed:
 * __DateTime::Format::ISO8601__
 * __LWP::Protocol::https__ (for TLS access)
 
-
-#### Linux in general
-
-On many Linux distributions these can be installed from packages `libmediawiki-api-perl`,  `libdatetime-format-iso8601-perl`, and `perl-lwp-protocol-https` respectively.
-
 #### ArchLinux
 
 On ArchLinux the packages are named `perl-mediawiki-api perl-datetime-format-iso8601 perl-lwp-protocol-https` and are optional dependencies of `git`.
 
-#### Gentoo
+#### Debian
 
-For Gentoo-based Linux distributions, they can be installed by emerging `dev-perl/MediaWiki-API` and `dev-perl/DateTime-Format-ISO8601`.
-
-On OS X, they can be installed using the CPAN installation tool:
-
-```shell
-sudo cpan MediaWiki::API
-sudo cpan DateTime::Format::ISO8601
-```
+On Debian-based systems __LWP::Protocol::https__ is available as `liblwp-protocol-https-perl` package.
 
 #### FreeBSD
 
@@ -45,9 +33,20 @@ cd /usr/ports/devel/p5-MediaWiki-API
 make install
 ```
 
-#### Debian
+#### Gentoo
 
-On Debian-based systems __LWP::Protocol::https__ is available as `liblwp-protocol-https-perl` package.
+For Gentoo-based Linux distributions, they can be installed by emerging `dev-perl/MediaWiki-API` and `dev-perl/DateTime-Format-ISO8601`.
+
+On OS X, they can be installed using the CPAN installation tool:
+
+```shell
+sudo cpan MediaWiki::API
+sudo cpan DateTime::Format::ISO8601
+```
+
+#### Linux in general
+
+On many Linux distributions these can be installed from packages `libmediawiki-api-perl`,  `libdatetime-format-iso8601-perl`, and `perl-lwp-protocol-https` respectively.
 
 
 ### Git-Mediawiki

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -8,10 +8,16 @@ You need to have the following Perl packages installed:
 
 * __MediaWiki::API__ (recent version. Version 0.39 works. Version 0.34 won't work with mediafiles)
 * __DateTime::Format::ISO8601__
+* __LWP::Protocol::https__ (for TLS access)
 
-On many distributions of Linux, these can be installed from packages `libmediawiki-api-perl` and `libdatetime-format-iso8601-perl`, respectively.
 
-For Gentoo-based Linux distributions they can be installed by emerging `dev-perl/MediaWiki-API` and `dev-perl/DateTime-Format-ISO8601`.
+#### Linux in general
+
+On many Linux distributions these can be installed from packages `libmediawiki-api-perl`,  `libdatetime-format-iso8601-perl`, and `perl-lwp-protocol-https` respectively.
+
+#### Gentoo
+
+For Gentoo-based Linux distributions, they can be installed by emerging `dev-perl/MediaWiki-API` and `dev-perl/DateTime-Format-ISO8601`.
 
 On OS X, they can be installed using the CPAN installation tool:
 
@@ -20,7 +26,10 @@ sudo cpan MediaWiki::API
 sudo cpan DateTime::Format::ISO8601
 ```
 
+#### FreeBSD
+
 On FreeBSD, both dependencies are available from ports or packages:
+
 ```shell
 # Through packages
 pkg install p5-MediaWiki-API p5-DateTime-Format-ISO8601
@@ -32,11 +41,9 @@ cd /usr/ports/devel/p5-MediaWiki-API
 make install
 ```
 
-To access HTTPS wikis, you may also need
+#### Debian
 
-* __LWP::Protocol::https__
-
-On Linux, the package is called `perl-lwp-protocol-https`, or `liblwp-protocol-https-perl` on Debian-based systems.
+On Debian-based systems __LWP::Protocol::https__ is available as `liblwp-protocol-https-perl` package.
 
 ### Git-Mediawiki
 

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -88,7 +88,7 @@ and/or select the content of MediaWiki Categories with:
 
     git clone -c remote.origin.categories='First Second' mediawiki::http://yourwikiadress.com
 
-By default, only the main namespace is inspected. But you can also specify other namespaces with the [following patchset](https://github.com/Git-Mediawiki/Git-Mediawiki/issues/10):
+By default, only the main namespace is inspected. But you can also specify other namespaces:
 
     git clone -c remote.origin.namespaces='(Main) Talk' mediawiki::http://yourwikiadress.com
 

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -94,15 +94,13 @@ By default, only the main namespace is inspected. But you can also specify other
 
 ### Shallow imports
 
-It is also possible to import only the last revision of a wiki. This is done using the `remote.origin.shallow` configuration variable. To set it during a clone, use:
+It is also possible to import only the last revision of a wiki. This is done using the `remote.origin.shallow` configuration variable. To apply the variable once during the clone, use:
 
     git -c remote.origin.shallow=true clone mediawiki::http://example.com/wiki/
 
-Alternatively, you may let clone write the value to the `.git/config` file to have further `git fetch` import only the last revision of each page too with
+ You can set this variable permanently by using the `-c` option behind the clone command. This will write the value to git's repository config. Any consecutive pull or fetch will skip the intermediary versions, and only fetch the latest version of the pages.
 
     git clone -c remote.origin.shallow=true mediawiki::http://example.com/wiki/
-
-(i.e. `-c` option used after `clone` in the command)
 
 ## Authentication
 

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -60,6 +60,8 @@ Alternatively, you may install Git-Mediawiki manually:
 Then, the first operation you should do is cloning the remote mediawiki. To do so, run the command
 
     git clone mediawiki::http://yourwikiadress.com
+		
+*Note: Only the main namespace is fetched this way! How to expand the clone to more namespaces, *
 
 You can commit your changes locally as usual with the command
 
@@ -77,20 +79,28 @@ It is strongly recommanded to run `git pull --rebase` after each `git push`.
 
 Knowing those commands, you can now edit your wiki with your favorite text editor!
 
-## Partial import of a Wiki
+## Modify import scope
+
 ### Limit the pages to be imported
 
 If you don't want to clone the whole wiki, you can import only some pages with:
 
     git clone -c remote.origin.pages='A_page Another_page' mediawiki::http://yourwikiadress.com
-
+		
 and/or select the content of MediaWiki Categories with:
 
     git clone -c remote.origin.categories='First Second' mediawiki::http://yourwikiadress.com
 
-By default, only the main namespace is inspected. But you can also specify other namespaces:
+### Changing processed namespaces
 
-    git clone -c remote.origin.namespaces='(Main) Talk' mediawiki::http://yourwikiadress.com
+To extend the import to more than the `(Main)` namespace, you can specify a list of the namespaces to process:
+
+    git clone -c remote.origin.namespaces='(Main) Talk Template Template_talk' mediawiki::http://yourwikiadress.com
+		
+*Note: Namespaces are addressed with their cannonical name, spaces in the name need to be replaced with underscores.*
+
+You can get  all cannonical namespaces of a wiki as a list from the API,  by sending this request:
+    api.php?action=query&meta=siteinfo&siprop=namespaces&formatversion=2
 
 ### Shallow imports
 
@@ -101,6 +111,7 @@ It is also possible to import only the last revision of a wiki. This is done usi
  You can set this variable permanently by using the `-c` option behind the clone command. This will write the value to git's repository config. Any consecutive pull or fetch will skip the intermediary versions, and only fetch the latest version of the pages.
 
     git clone -c remote.origin.shallow=true mediawiki::http://example.com/wiki/
+
 
 ## Authentication
 

--- a/docs/User-manual.md
+++ b/docs/User-manual.md
@@ -15,6 +15,10 @@ You need to have the following Perl packages installed:
 
 On many Linux distributions these can be installed from packages `libmediawiki-api-perl`,  `libdatetime-format-iso8601-perl`, and `perl-lwp-protocol-https` respectively.
 
+#### ArchLinux
+
+On ArchLinux the packages are named `perl-mediawiki-api perl-datetime-format-iso8601 perl-lwp-protocol-https` and are optional dependencies of `git`.
+
 #### Gentoo
 
 For Gentoo-based Linux distributions, they can be installed by emerging `dev-perl/MediaWiki-API` and `dev-perl/DateTime-Format-ISO8601`.
@@ -44,6 +48,7 @@ make install
 #### Debian
 
 On Debian-based systems __LWP::Protocol::https__ is available as `liblwp-protocol-https-perl` package.
+
 
 ### Git-Mediawiki
 


### PR DESCRIPTION
- Remove outdated hint to a patch set (which is already merged). cba71f3678eabf28b6e8d0966a0c3199aac8ff1c
- Improve language on the 'shallow imports' section a9f704c2e571ef0c3b3cbe921298b252a0d0dd1b
- Add/Improve docs on namespaces 14ff23d25ee0b8e020626fd021d1bbaa4e1d0b93
- - Change headline from 'Partial import of a Wiki' to 'Modify import scope', as adding additional namespaces will expand, not limit the import
- - Add docs on how namespaces with spaces are specified
- - Expand the example variable, to include examples which contain spaces
- - Add URL for requesting a list of namespaces from the API
- - Rewording
- Dependency section
- - Organize the dependencies section better 8805534b3545f5e502d92dbefe774feb9a4958d9
- - Add ArchLinux to the Dependencies section 8ec8ca558c068519a5fec79241a75954f80d3849
- - Sort Dependencies section alphabetically; move general Linux to the bottom 3ec79e46b9ef3a063aa2959dd75081203d2f1047
- Add a general note that the official git repository is not up-to-date e8184cda694cdfe6fffe518d63304811930b62f5 (referring to https://github.com/Git-Mediawiki/Git-Mediawiki/issues/82)