### PR TITLE
Fix characters in author string preventing import

### DIFF
--- a/Git/Mediawiki.pm
+++ b/Git/Mediawiki.pm
@@ -20,7 +20,7 @@ BEGIN {
 	@ISA = qw(Exporter);
 
 	# Methods which can be called as standalone functions as well:
-	@EXPORT_OK = qw(clean_filename smudge_filename connect_maybe
+	@EXPORT_OK = qw(escape_author clean_filename smudge_filename connect_maybe
 									EMPTY HTTP_CODE_OK HTTP_CODE_PAGE_NOT_FOUND);
 }
 
@@ -33,6 +33,12 @@ use constant EMPTY => q{};
 # HTTP codes
 use constant HTTP_CODE_OK => 200;
 use constant HTTP_CODE_PAGE_NOT_FOUND => 404;
+
+sub escape_author {
+    my $string = shift;
+    $string =~ s/([<>@])/uri_escape($1)/ge;
+    return $string;
+}
 
 sub clean_filename {
 	my $filename = shift;

--- a/git-remote-mediawiki
+++ b/git-remote-mediawiki
@@ -17,7 +17,7 @@ use lib (split(/:/, $ENV{GITPERLLIB} || ""));
 
 use MediaWiki::API;
 use Git;
-use Git::Mediawiki qw(clean_filename smudge_filename connect_maybe EMPTY HTTP_CODE_OK);
+use Git::Mediawiki qw(escape_author clean_filename smudge_filename connect_maybe EMPTY HTTP_CODE_OK);
 use DateTime::Format::ISO8601;
 use warnings;
 
@@ -969,7 +969,7 @@ sub handle_result_page {
 		$n_actual++;
 
 		my %commit;
-		$commit{author} = $rev->{user} || 'Anonymous';
+		$commit{author} = escape_author($rev->{user}) || 'Anonymous';
 		$commit{comment} = $rev->{comment} || EMPTY_MESSAGE;
 		$commit{title} = smudge_filename($page_title);
 		$commit{mw_revision} = $rev->{revid};


### PR DESCRIPTION
This commit urlencodes '<', '>', and '@', which should be the minimum requirement to convert the author value from the API to a valid author string in a git commit.

The problem can be replacicated by exporting [Template:Infobox atom](https://en.wikipedia.org/wiki/Template:Infobox_atom) and importing it into a test wiki.

This revision: https://en.wikipedia.org/w/index.php?title=Template:Infobox_atom&oldid=1043672020 ends up having the author field set to 'MediaWiki>Goszei' in the test wiki, which then causes the "fatal: Missing < in ident string" error. #88

The imported commit now looks like: Author: MediaWiki%3EGoszei <MediaWiki%3EGoszei@examplewiki.local:8080/w>

Was not sure what the best strategy to handle this case was, but cloning and pulling no longer fails, and no information is lost.

This problem can be further mitigated by properly configuring identities on import.

Fixes #88